### PR TITLE
Support for previewing data (sent from admin interface)

### DIFF
--- a/locale/en/messages.po
+++ b/locale/en/messages.po
@@ -707,6 +707,9 @@ msgstr "Listing total of {{count}} libraries."
 msgid "nice URL slug missing"
 msgstr "nice URL slug missing"
 
+msgid "This is preview mode"
+msgstr "This is preview mode"
+
 #~ msgid "library name, service, city, postcode..."
 #~ msgstr "library name, service, city, postcode..."
 

--- a/locale/fi/messages.po
+++ b/locale/fi/messages.po
@@ -707,6 +707,9 @@ msgstr "Hakemistossa yhteensä {{count}} kirjastoa."
 msgid "nice URL slug missing"
 msgstr "kaunis URL-tunniste puuttuu"
 
+msgid "This is preview mode"
+msgstr "Tämä on esikatselutila"
+
 #~ msgid "PL"
 #~ msgstr "PL"
 

--- a/locale/sv/messages.po
+++ b/locale/sv/messages.po
@@ -707,6 +707,9 @@ msgstr "Totalt {{count}} bibliotek."
 msgid "nice URL slug missing"
 msgstr "snyggt URL-namn fattas"
 
+msgid "This is preview mode"
+msgstr "Detta är förgranskningsläge"
+
 #~ msgid "PL"
 #~ msgstr "PB"
 

--- a/views/library_details.mustache
+++ b/views/library_details.mustache
@@ -1,6 +1,25 @@
 {{{header}}}
 
 {{#data}}
+
+{{#preview_mode}}
+    <style type="text/css">
+        #preview-mode-warning {
+            background-color: #FFE1D9;
+            border: 1px solid red;
+            padding: 5px;
+            margin-bottom: 10px;
+        }
+
+        #preview-mode-warning h1 {
+            color: red;
+        }
+    </style>
+    <div id="preview-mode-warning">
+        <h1>_("This is preview mode")</h1>
+    </div>
+{{/preview_mode}}
+
 <div class="row-fluid" itemscope itemtype="http://schema.org/Library">
   <div class="span6">
 
@@ -194,7 +213,7 @@
 			{{/opening_hours.has_opening_hours}}
         {{/neveropen}}
     </div>
-    
+
     <div class="contactdetails">
 		{{#contact.homepage__("locale")}}
 		<dd>
@@ -289,7 +308,7 @@
 	    <dd><i class="icon-envelope"></i> <a href="mailto:{{contact.email}}" itemprop="email">{{contact.email}}</a></dd>
 	    {{/contact.email}}
     </div>
-    
+
     <div class="buildinginfo">
         {{#image_url}}
         <img src="{{image_url}}" alt="{{name__("locale")}}" itemprop="image photo">
@@ -304,7 +323,7 @@
         {{/contact.building_year}}
         {{#contact.building_architect}}
             <tr><th>_("Architect"):</th><td>{{contact.building_architect}}</td></tr>
-        {{/contact.building_architect}} 
+        {{/contact.building_architect}}
         <td><th colspan="2">&nbsp;</td></tr>
 
 		{{#accessibility_available}}


### PR DESCRIPTION
This patch would allow rendering preview of unsaved library details using the standard public view. This would be useful in the admin interface because the libraries' staff have trouble visualizing changes.
