### PR TITLE
Increase query size limit from 999 to 5000 to include all records

### DIFF
--- a/server.js
+++ b/server.js
@@ -884,7 +884,7 @@ var http = require('http');
 function get_libraries(callback) {
 
   var query = {
-    'size': 999,
+    'size': 5000,
     'sort': [ { 'name_fi' : {} } ],
     'query' : {
         'filtered' : {


### PR DESCRIPTION
There are about 2000 organisation records (and increasing), so we need bigger a cap than 999.