### PR TITLE
Fix for supporting Elasticsearch 1.5

### DIFF
--- a/server.js
+++ b/server.js
@@ -1247,7 +1247,7 @@ function get_library_by_id(id, callback) {
       });
       es_res.on('end', function() {
           dataobj = JSON.parse(data);
-          if (dataobj.exists) {
+          if (dataobj.exists || dataobj.found) {
             add_library_metadata(dataobj, callback);
           } else {
             rlog('Library with id ' + id + ' does not exist.');


### PR DESCRIPTION
Field 'exists' appears to be renamed to 'found' in newer ES.